### PR TITLE
Prevent error chunk.choices is not iterable

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,10 @@ const handlePromptStream = async (req, res) => {
 
     // Process each chunk from the stream
     for await (const chunk of stream) {
+      if (!chunk.choices) {
+        console.warn("Non-standard chunk:", chunk);
+        continue;
+      }
       for (const choice of chunk.choices) {
         // console.log(`>> Choice: ${JSON.stringify(choice)}`);
         // Handle completion of the response


### PR DESCRIPTION
When we are using OpenAPI compatible API such as OpenWebUI we are receiving a non standard chunk causing the following error:

Error calling OpenAI API: chunk.choices is not iterable

In order to make it compatible with OpenWebUI we can simply log the non standard chunk. 

The following will be logged when using OpenWebUI as an OpenAI compatible endpoint.

Non-standard chunk: {
  sources: [
    {
      source: [Object],
      document: [Array],
      metadata: [Array],
      distances: [Array]
    }
  ]
}